### PR TITLE
chore: dependenciesからpnpmを削除

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "path": "^0.12.7",
-    "pnpm": "^9.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-router": "^6.22.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       path:
         specifier: ^0.12.7
         version: 0.12.7
-      pnpm:
-        specifier: ^9.0.0
-        version: 9.1.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -633,11 +630,6 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-
-  pnpm@9.1.1:
-    resolution: {integrity: sha512-FOkVdZwR936sB/q6TQGcGT7IY3Ip5i7Jnu+3zzw7dcZER4grfEhRQkUe46a0CAWc37e3+gNBuXXxLQ92KccRlQ==}
-    engines: {node: '>=18.12'}
-    hasBin: true
 
   postcss@8.4.38:
     resolution: {integrity: sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==}
@@ -1296,8 +1288,6 @@ snapshots:
   picocolors@1.0.0: {}
 
   picomatch@2.3.1: {}
-
-  pnpm@9.1.1: {}
 
   postcss@8.4.38:
     dependencies:


### PR DESCRIPTION
corepackの設定と重複するため